### PR TITLE
Warnings

### DIFF
--- a/include/QIClib_bits/basic/random.hpp
+++ b/include/QIClib_bits/basic/random.hpp
@@ -187,8 +187,10 @@ inline TR randN(const arma::uword& m, const arma::uword& n,
 
 template <typename T1 = int,
           typename TR = typename std::enable_if<
-            std::is_arithmetic<T1>::value || is_complex<T1>::value, T1>::type>
-inline TR randI(const arma::Col<arma::sword>& range = {0, 1000}) {
+            std::is_arithmetic<T1>::value || is_complex<T1>::value, T1>::type,
+          typename TA = typename std::conditional<
+            std::is_unsigned<T1>::value, arma::uword, arma::sword>::type>
+inline TR randI(const arma::Col<TA>& range = {0, 1000}) {
 #ifndef QICLIB_NO_DEBUG
   if (range.n_elem != 2 || range.at(0) > range.at(1))
     throw Exception("qic::randI", "Not proper range");
@@ -198,7 +200,7 @@ inline TR randI(const arma::Col<arma::sword>& range = {0, 1000}) {
     throw Exception("qic::randI", "Negative range for unsigned type");
 #endif
 
-  std::uniform_int_distribution<arma::sword> dis(range.at(0), range.at(1));
+  std::uniform_int_distribution<TA> dis(range.at(0), range.at(1));
 
   if (is_floating_point_var<T1>::value) {
     return static_cast<typename arma::get_pod_type<T1>::result>(dis(rdevs.rng));
@@ -215,12 +217,13 @@ inline TR randI(const arma::Col<arma::sword>& range = {0, 1000}) {
 //****************************************************************************
 
 template <typename T1 = arma::ivec,
-          typename TR = typename std::enable_if<is_arma_type_var<T1>::value &&
-                                                  (arma::is_Col<T1>::value ||
-                                                   arma::is_Row<T1>::value),
-                                                T1>::type>
+          typename TR = typename std::enable_if<
+            is_arma_type_var<T1>::value && (arma::is_Col<T1>::value ||
+                arma::is_Row<T1>::value), T1>::type,
+          typename TA = typename std::conditional<
+            std::is_unsigned<T1>::value, arma::uword, arma::sword>::type>
 inline TR randI(const arma::uword& N,
-                const arma::Col<arma::sword>& range = {0, 1000}) {
+                const arma::Col<TA>& range = {0, 1000}) {
 #ifndef QICLIB_NO_DEBUG
   if (range.n_elem != 2 || range.at(0) > range.at(1))
     throw Exception("qic::randI", "Not proper range");
@@ -229,7 +232,7 @@ inline TR randI(const arma::uword& N,
     throw Exception("qic::randI", "Negative range for unsigned type");
 #endif
 
-  std::uniform_int_distribution<arma::sword> dis(range.at(0), range.at(1));
+  std::uniform_int_distribution<TA> dis(range.at(0), range.at(1));
   T1 ret(N);
 
   if (std::is_same<trait::eT<T1>, trait::pT<T1> >::value) {
@@ -250,9 +253,11 @@ inline TR randI(const arma::uword& N,
 template <typename T1 = arma::imat,
           typename TR = typename std::enable_if<
             is_arma_type_var<T1>::value && arma::is_Mat_only<T1>::value,
-            arma::Mat<trait::eT<T1> > >::type>
+            arma::Mat<trait::eT<T1> > >::type,
+          typename TA = typename std::conditional<
+            std::is_unsigned<T1>::value, arma::uword, arma::sword>::type>
 inline TR randI(const arma::uword& m, const arma::uword& n,
-                const arma::Col<arma::sword>& range = {0, 1000}) {
+                const arma::Col<TA>& range = {0, 1000}) {
 #ifndef QICLIB_NO_DEBUG
   if (range.n_elem != 2 || range.at(0) > range.at(1))
     throw Exception("qic::randI", "Not proper range");
@@ -261,7 +266,7 @@ inline TR randI(const arma::uword& m, const arma::uword& n,
     throw Exception("qic::randI", "Negative range for unsigned type");
 #endif
 
-  std::uniform_int_distribution<arma::sword> dis(range.at(0), range.at(1));
+  std::uniform_int_distribution<TA> dis(range.at(0), range.at(1));
   arma::Mat<trait::eT<T1> > ret(m, n);
 
   if (std::is_same<trait::eT<T1>, trait::pT<T1> >::value) {

--- a/include/QIClib_bits/class/constants.hpp
+++ b/include/QIClib_bits/class/constants.hpp
@@ -60,8 +60,7 @@ class SPM final : public _internal::Singleton<const SPM<T1> > {
     proj3;
 
  private:
-  SPM() {
-    S.set_size(4);
+  SPM(): S(4), basis2(2, 4), basis3(3, 4), proj2(2, 4), proj3(3, 4) {
 
     S.at(0) << 1.0 << 0.0 << arma::endr << 0.0 << 1.0 << arma::endr;
 
@@ -73,8 +72,6 @@ class SPM final : public _internal::Singleton<const SPM<T1> > {
     S.at(3) << 1.0 << 0.0 << arma::endr << 0.0 << -1.0 << arma::endr;
 
     //**************************************************************************
-
-    basis2.set_size(2, 4);
 
     basis2.at(0, 0) << 1.0 << 0.0;
     basis2.at(1, 0) << 0.0 << 1.0;
@@ -89,8 +86,6 @@ class SPM final : public _internal::Singleton<const SPM<T1> > {
     basis2.at(1, 3) = basis2.at(1, 0);
 
     //**************************************************************************
-
-    basis3.set_size(3, 4);
 
     basis3.at(0, 0) << 1.0 << 0.0 << 0.0;
     basis3.at(1, 0) << 0.0 << 1.0 << 0.0;
@@ -110,7 +105,6 @@ class SPM final : public _internal::Singleton<const SPM<T1> > {
 
     //**************************************************************************
 
-    proj2.set_size(2, 4);
     proj2.at(0, 0) = basis2.at(0, 0) * basis2.at(0, 0).t();
     proj2.at(1, 0) = basis2.at(1, 0) * basis2.at(1, 0).t();
     proj2.at(0, 1) = basis2.at(0, 1) * basis2.at(0, 1).t();
@@ -122,7 +116,6 @@ class SPM final : public _internal::Singleton<const SPM<T1> > {
 
     //**************************************************************************
 
-    proj3.set_size(3, 4);
     proj3.at(0, 0) = basis3.at(0, 0) * basis3.at(0, 0).t();
     proj3.at(1, 0) = basis3.at(1, 0) * basis3.at(1, 0).t();
     proj3.at(2, 0) = basis3.at(2, 0) * basis3.at(2, 0).t();

--- a/include/QIClib_bits/class/init.hpp
+++ b/include/QIClib_bits/class/init.hpp
@@ -31,26 +31,25 @@ class Init final : public _internal::Singleton<const Init> {
   friend class _internal::Singleton<const Init>;
 
  private:
-  std::time_t date1, date2, date3;
+  std::time_t date_start;
 
-  Init() {
+  Init(): date_start(std::time(nullptr)) {
     std::cout << std::endl
               << ">>> Starting QIClib..." << std::endl;
-    date1 = std::time(nullptr);
-    std::cout << ">>> " << std::ctime(&date1) << std::endl;
+    std::cout << ">>> " << std::ctime(&date_start) << std::endl;
   }
 
   ~Init() {
-    date2 = std::time(nullptr);
-    date3 = date2 - date1;
-    auto minutes = date3 / 60;
+    std::time_t date_end = std::time(nullptr);
+    std::time_t date_diff = date_end - date_start;
+    auto minutes = date_diff / 60;
     auto hours = minutes / 60;
     std::cout << std::endl
               << ">>> Exiting QIClib..." << std::endl;
     std::cout << ">>> Total elapsed time... " << hours << " hrs. "
-              << minutes % 60 << " mins. " << date3 % 60 << " seconds"
+              << minutes % 60 << " mins. " << date_diff % 60 << " seconds"
               << std::endl;
-    std::cout << ">>> " << std::ctime(&date2) << std::endl;
+    std::cout << ">>> " << std::ctime(&date_end) << std::endl;
   }
 };
 


### PR DESCRIPTION
These two commits deal with GCC warnings generated with some strictness flags. The functionality or exposed interface is not affected (in 526db22 arguments taken by overloads of `qic::randI()` are modified but this function is not used in any published code AFAIK). If a range is provided for `qic::randI()` via initializer list, nothing changes either, keeping consistency with the documentation.
